### PR TITLE
adjust default port configuration

### DIFF
--- a/nodes/redmatic-homekit-camera.html
+++ b/nodes/redmatic-homekit-camera.html
@@ -11,8 +11,8 @@
                     return Boolean(String(val).match(/^\d{3}-\d{2}-\d{3}$/));
                 }
             },
-            port: {value: 51912, type: Number, required: true, validate: function (val) {
-                    return val > 1024 && val < 65536;
+            port: {value: '51912', required: true, validate: function (val) {
+                    return RED.validators.number(val) && val > 1024 && val < 65536;
                 }
             },videoProcessor: {value: 'ffmpeg'},
             source: {value: '-re -i rtsp://myfancy_rtsp_stream'},

--- a/nodes/redmatic-homekit-tv.html
+++ b/nodes/redmatic-homekit-tv.html
@@ -11,8 +11,8 @@
                     return Boolean(String(val).match(/^\d{3}-\d{2}-\d{3}$/));
                 }
             },
-            port: {value: 51952, type: Number, required: true, validate: function (val) {
-                    return val > 1024 && val < 65536;
+            port: {value: '51952', required: true, validate: function (val) {
+                    return RED.validators.number(val) && val > 1024 && val < 65536;
                 }
             },
             inputsources: {


### PR DESCRIPTION
This patch changes the default port configuration of the camera- and tv-nodes to not fail with Node-RED >= 1.3.0 .

fixes #344 